### PR TITLE
Implement LED Indicator Management with Adjustable Brightness and Color for ESP32-S3

### DIFF
--- a/ESP32-NF-MQTT-DHT/ESP32-NF-MQTT-DHT.nfproj
+++ b/ESP32-NF-MQTT-DHT/ESP32-NF-MQTT-DHT.nfproj
@@ -29,6 +29,7 @@
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
     <Compile Include="ExtensionAttribute.cs" />
+    <Compile Include="Services\LedIndicatorService.cs" />
     <Compile Include="Services\LogService.cs" />
     <Compile Include="Services\MQTT\Contracts\IMqttConnectionManager.cs" />
     <Compile Include="Services\MQTT\Contracts\ISensorDataPublisher.cs" />
@@ -97,11 +98,17 @@
     <Reference Include="Iot.Device.Shtc3">
       <HintPath>..\packages\nanoFramework.Iot.Device.Shtc3.1.2.852\lib\Iot.Device.Shtc3.dll</HintPath>
     </Reference>
+    <Reference Include="Iot.Device.Ws28xx.Esp32">
+      <HintPath>..\packages\nanoFramework.Iot.Device.Ws28xx.Esp32.1.2.852\lib\Iot.Device.Ws28xx.Esp32.dll</HintPath>
+    </Reference>
     <Reference Include="mscorlib">
       <HintPath>..\packages\nanoFramework.CoreLibrary.1.17.7\lib\mscorlib.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.DependencyInjection">
       <HintPath>..\packages\nanoFramework.DependencyInjection.1.1.30\lib\nanoFramework.DependencyInjection.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.Graphics.Core">
+      <HintPath>..\packages\nanoFramework.Graphics.Core.1.2.42\lib\nanoFramework.Graphics.Core.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.Hardware.Esp32">
       <HintPath>..\packages\nanoFramework.Hardware.Esp32.1.6.33\lib\nanoFramework.Hardware.Esp32.dll</HintPath>

--- a/ESP32-NF-MQTT-DHT/ESP32-NF-MQTT-DHT.nfproj
+++ b/ESP32-NF-MQTT-DHT/ESP32-NF-MQTT-DHT.nfproj
@@ -144,7 +144,7 @@
       <HintPath>..\packages\nanoFramework.System.Text.1.3.36\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.WebServer">
-      <HintPath>..\packages\nanoFramework.WebServer.1.2.112\lib\nanoFramework.WebServer.dll</HintPath>
+      <HintPath>..\packages\nanoFramework.WebServer.1.2.116\lib\nanoFramework.WebServer.dll</HintPath>
     </Reference>
     <Reference Include="System.Buffers.Binary.BinaryPrimitives">
       <HintPath>..\packages\nanoFramework.System.Buffers.Binary.BinaryPrimitives.1.2.848\lib\System.Buffers.Binary.BinaryPrimitives.dll</HintPath>
@@ -177,7 +177,7 @@
       <HintPath>..\packages\nanoFramework.System.Net.1.11.37\lib\System.Net.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http">
-      <HintPath>..\packages\nanoFramework.System.Net.Http.Server.1.5.189\lib\System.Net.Http.dll</HintPath>
+      <HintPath>..\packages\nanoFramework.System.Net.Http.Server.1.5.192\lib\System.Net.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Sockets.TcpClient">
       <HintPath>..\packages\nanoframework.System.Net.Sockets.TcpClient.1.1.118\lib\System.Net.Sockets.TcpClient.dll</HintPath>

--- a/ESP32-NF-MQTT-DHT/Services/LedIndicatorService.cs
+++ b/ESP32-NF-MQTT-DHT/Services/LedIndicatorService.cs
@@ -1,0 +1,81 @@
+﻿namespace ESP32_NF_MQTT_DHT.Services
+{
+    using System.Drawing;
+    using System.Threading;
+
+    using Iot.Device.Ws28xx.Esp32;
+
+    /// <summary>
+    /// ONLY FOR ESP32-S3!!!
+    /// Manages an LED indicator, allowing it to be started, stopped, and set to a specific color with adjustable
+    /// brightness.
+    /// Runs on a separate thread to update the LED state.
+    /// </summary>
+    public class LedIndicatorService
+    {
+        private readonly Ws2812c _ws2812;
+        private Thread _ledThread;
+        private bool _isRunning;
+        private Color _currentColor = Color.Black;
+
+        private readonly float _brightness;
+
+        public LedIndicatorService(int ledPin, float brightness = 0.2f)
+        {
+            _brightness = brightness;
+            _ws2812 = new Ws2812c(ledPin, 1);
+        }
+
+        /// <summary>
+        /// Starts the LED thread if it is not already running. Sets the running state to true and initiates the thread
+        /// execution.
+        /// </summary>
+        public void Start()
+        {
+            if (_isRunning) return;
+
+            _isRunning = true;
+            _ledThread = new Thread(this.Run);
+            _ledThread.Start();
+        }
+
+        /// <summary>
+        /// Stops the running process by setting the running state to false. Changes the color to black.
+        /// </summary>
+        public void Stop()
+        {
+            _isRunning = false;
+            this.SetColor(Color.Black);
+        }
+
+        /// <summary>
+        /// Sets the current color and updates the display with the adjusted brightness.
+        /// </summary>
+        /// <param name="color">Specifies the color to be adjusted and set on the display.</param>
+        public void SetColor(Color color)
+        {
+            _currentColor = this.AdjustBrightness(color, _brightness);
+            _ws2812.Image.SetPixel(0, 0, _currentColor);
+            _ws2812.Update();
+        }
+
+        private void Run()
+        {
+            while (_isRunning)
+            {
+                this.SetColor(_currentColor);
+                Thread.Sleep(500);
+            }
+        }
+
+        private Color AdjustBrightness(Color color, float brightness)
+        {
+            brightness = brightness < 0 ? 0 : brightness > 1 ? 1 : brightness;
+
+            return Color.FromArgb(
+                (byte)(color.R * brightness),
+                (byte)(color.G * brightness),
+                (byte)(color.B * brightness));
+        }
+    }
+}

--- a/ESP32-NF-MQTT-DHT/Services/TcpListenerService.cs
+++ b/ESP32-NF-MQTT-DHT/Services/TcpListenerService.cs
@@ -1,19 +1,20 @@
 ﻿namespace ESP32_NF_MQTT_DHT.Services
 {
+    using Contracts;
+
+    using ESP32_NF_MQTT_DHT.Helpers;
+
+    using nanoFramework.Runtime.Native;
+
     using System;
     using System.Collections;
+    using System.Diagnostics;
     using System.IO;
     using System.Net;
     using System.Net.NetworkInformation;
     using System.Net.Sockets;
     using System.Text;
     using System.Threading;
-
-    using Contracts;
-
-    using ESP32_NF_MQTT_DHT.Helpers;
-
-    using nanoFramework.Runtime.Native;
 
     using static Settings.DeviceSettings;
     using static Settings.TcpSettings;
@@ -319,11 +320,24 @@
             {
                 Version firmwareVersion = SystemInfo.Version;
                 string versionString = $"{firmwareVersion.Major}.{firmwareVersion.Minor}.{firmwareVersion.Build}.{firmwareVersion.Revision}";
-                string info = "Device: " + DeviceName + "\r\n" +
-                              "Firmware Version: " + versionString + "\r\n" +
-                              "IP: " + GetCurrentIpAddress() + "\r\n" +
-                              "Uptime: " + _uptimeService.GetUptime() + "\r\n" +
-                              "Sensor Interval: " + _sensorInterval + " ms";
+                string processor = SystemInfo.OEMString;
+                string familyName = SystemInfo.TargetName;
+                uint freeMemory = GC.Run(false);
+
+                var networkInterface = NetworkInterface.GetAllNetworkInterfaces()[0];
+                string ip = networkInterface.IPv4Address;
+                string mac = BitConverter.ToString(networkInterface.PhysicalAddress);
+
+                string info = $"Device: {DeviceName}\r\n" +
+                              $"Firmware Version: {versionString}\r\n" +
+                              $"Platform: {SystemInfo.Platform}\r\n" +
+                              $"Family: {familyName}\r\n" +
+                              $"CPU: {processor}\r\n" +
+                              $"Free RAM: {freeMemory} bytes\r\n" +
+                              $"IP: {ip}\r\n" +
+                              $"MAC: {mac}\r\n" +
+                              $"Uptime: {_uptimeService.GetUptime()}\r\n" +
+                              $"Sensor Interval: {_sensorInterval} ms";
                 this.WriteToStream(writer, info);
                 return false;
             }));

--- a/ESP32-NF-MQTT-DHT/packages.config
+++ b/ESP32-NF-MQTT-DHT/packages.config
@@ -25,12 +25,12 @@
   <package id="nanoFramework.System.IO.Streams" version="1.1.91" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Math" version="1.5.112" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Net" version="1.11.37" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.189" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net.Http.Server" version="1.5.189" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.192" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net.Http.Server" version="1.5.192" targetFramework="netnano1.0" />
   <package id="nanoframework.System.Net.Sockets.TcpClient" version="1.1.118" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.3.36" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.50" targetFramework="netnano1.0" />
-  <package id="nanoFramework.WebServer" version="1.2.112" targetFramework="netnano1.0" />
+  <package id="nanoFramework.WebServer" version="1.2.116" targetFramework="netnano1.0" />
   <package id="UnitsNet.nanoFramework.Duration" version="5.73.0" targetFramework="netnano1.0" />
   <package id="UnitsNet.nanoFramework.ElectricResistance" version="5.73.0" targetFramework="netnano1.0" />
   <package id="UnitsNet.nanoFramework.Length" version="5.73.0" targetFramework="netnano1.0" />


### PR DESCRIPTION
#### PR Classification
New feature implementation for LED indicator management.

#### PR Summary
This pull request introduces a new service for managing an LED indicator with adjustable brightness and color for the ESP32-S3 platform, along with necessary project file updates and package version upgrades.
- `LedIndicatorService.cs`: Added a new service to control LED indicators.
- `ESP32-NF-MQTT-DHT.nfproj`: Included the new service in the compilation list and added references to `Iot.Device.Ws28xx.Esp32` and `nanoFramework.Graphics.Core`.
- `TcpListenerService.cs`: Enhanced device information output and removed unnecessary using directives.
