### PR TITLE
Add OtaPackager Tool for Preparing OTA Artifacts

### DIFF
--- a/ESP32-NF-MQTT-DHT/ESP32-NF-MQTT-DHT.sln
+++ b/ESP32-NF-MQTT-DHT/ESP32-NF-MQTT-DHT.sln
@@ -1,0 +1,29 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tools", "Tools", "{07C2787E-EAC7-C090-1BA3-A61EC2A24D84}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OtaPackager", "Tools\OtaPackager\OtaPackager.csproj", "{A6BC8708-3BCA-CD74-B46B-7A5D438168D8}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A6BC8708-3BCA-CD74-B46B-7A5D438168D8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A6BC8708-3BCA-CD74-B46B-7A5D438168D8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A6BC8708-3BCA-CD74-B46B-7A5D438168D8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A6BC8708-3BCA-CD74-B46B-7A5D438168D8}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{A6BC8708-3BCA-CD74-B46B-7A5D438168D8} = {07C2787E-EAC7-C090-1BA3-A61EC2A24D84}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B4A7286C-EA6D-4AB4-84E6-B7A8BDC59FAA}
+	EndGlobalSection
+EndGlobal

--- a/ESP32-NF-MQTT-DHT/Tools/OtaPackager/OtaPackager.csproj
+++ b/ESP32-NF-MQTT-DHT/Tools/OtaPackager/OtaPackager.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/ESP32-NF-MQTT-DHT/Tools/OtaPackager/OtaPackager.sln
+++ b/ESP32-NF-MQTT-DHT/Tools/OtaPackager/OtaPackager.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OtaPackager", "OtaPackager.csproj", "{DC0FB292-9B47-CE2D-6751-16AB000DE010}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{DC0FB292-9B47-CE2D-6751-16AB000DE010}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DC0FB292-9B47-CE2D-6751-16AB000DE010}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DC0FB292-9B47-CE2D-6751-16AB000DE010}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DC0FB292-9B47-CE2D-6751-16AB000DE010}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E97C3F68-7EB2-42BA-BFAB-5F749B05F513}
+	EndGlobalSection
+EndGlobal

--- a/ESP32-NF-MQTT-DHT/Tools/OtaPackager/Program.cs
+++ b/ESP32-NF-MQTT-DHT/Tools/OtaPackager/Program.cs
@@ -1,0 +1,130 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+
+// Usage:
+// OtaPackager <inputDir> <version> <outputDir> [--main=App.pe] [--base-url=https://host/path/] [--include=App.pe;Lib.pe]
+
+if (args.Length < 3)
+{
+    Console.WriteLine("Usage: OtaPackager <inputDir> <version> <outputDir> [--main=App.pe] [--base-url=https://host/path/] [--include=App.pe;Lib.pe]");
+    return;
+}
+
+var inputDir = Path.GetFullPath(args[0]);
+var version = args[1];
+var outputDir = Path.GetFullPath(args[2]);
+string mainName = "App.pe";
+string baseUrl = string.Empty;
+string[] includeOnly = Array.Empty<string>();
+
+for (int i = 3; i < args.Length; i++)
+{
+    var a = args[i];
+    if (a.StartsWith("--main=")) mainName = a.Substring("--main=".Length);
+    else if (a.StartsWith("--base-url=")) baseUrl = a.Substring("--base-url=".Length);
+    else if (a.StartsWith("--include=")) includeOnly = a.Substring("--include=".Length).Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+}
+
+if (!Directory.Exists(inputDir))
+{
+    Console.WriteLine($"Input dir not found: {inputDir}");
+    return;
+}
+
+Directory.CreateDirectory(outputDir);
+
+var files = Directory.GetFiles(inputDir, "*.pe", SearchOption.TopDirectoryOnly);
+if (files.Length == 0)
+{
+    Console.WriteLine("No .pe files in input dir.");
+    return;
+}
+
+bool IsFrameworkPe(string fileName)
+{
+    // Exclude mscorlib, System.* and nanoFramework.* by default
+    if (string.Equals(fileName, "mscorlib.pe", StringComparison.OrdinalIgnoreCase)) return true;
+    if (fileName.StartsWith("System.", StringComparison.OrdinalIgnoreCase)) return true;
+    if (fileName.StartsWith("nanoFramework.", StringComparison.OrdinalIgnoreCase)) return true;
+    if (fileName.StartsWith("nanoframework.", StringComparison.OrdinalIgnoreCase)) return true;
+    return false;
+}
+
+bool ShouldInclude(string fileName)
+{
+    if (includeOnly.Length > 0)
+    {
+        foreach (var n in includeOnly)
+        {
+            if (string.Equals(n.Trim(), fileName, StringComparison.OrdinalIgnoreCase)) return true;
+        }
+        return false;
+    }
+
+    return !IsFrameworkPe(fileName);
+}
+
+string ToHexLower(byte[] b)
+{
+    var c = new char[b.Length * 2];
+    int i = 0;
+    foreach (var by in b)
+    {
+        c[i++] = GetHex(by >> 4);
+        c[i++] = GetHex(by & 0xF);
+    }
+    return new string(c);
+    static char GetHex(int n) => (char)(n < 10 ? '0' + n : 'a' + (n - 10));
+}
+
+if (!string.IsNullOrEmpty(baseUrl) && !baseUrl.EndsWith("/")) baseUrl += "/";
+
+var items = new List<object>();
+int copied = 0;
+var hashesTxt = new System.Text.StringBuilder();
+
+foreach (var f in files)
+{
+    var name = Path.GetFileName(f);
+    if (!ShouldInclude(name))
+    {
+        Console.WriteLine($"Skipping framework PE: {name}");
+        continue;
+    }
+
+    var dest = Path.Combine(outputDir, name);
+    File.Copy(f, dest, true);
+    copied++;
+
+    using var stream = File.OpenRead(f);
+    using var sha = SHA256.Create();
+    var hash = sha.ComputeHash(stream);
+    var hex = ToHexLower(hash);
+
+    var url = string.IsNullOrEmpty(baseUrl) ? name : (baseUrl + name);
+    items.Add(new { name, url, sha256 = hex });
+
+    hashesTxt.AppendLine($"{name}  sha256={hex}  bytes={new FileInfo(f).Length}");
+}
+
+if (items.Count == 0)
+{
+    Console.WriteLine("No eligible .pe files to package. Use --include to force explicit list.");
+    return;
+}
+
+// Ensure main entry is last in the manifest files order
+items = items.OrderBy(i => string.Equals(((dynamic)i).name, mainName, StringComparison.OrdinalIgnoreCase) ? 1 : 0).ToList();
+
+var manifest = new { version, files = items };
+var json = JsonSerializer.Serialize(manifest, new JsonSerializerOptions { WriteIndented = true });
+await File.WriteAllTextAsync(Path.Combine(outputDir, "manifest.json"), json);
+
+// Write a helper file for quick comparison on target logs
+await File.WriteAllTextAsync(Path.Combine(outputDir, "HASHES.txt"), hashesTxt.ToString());
+
+Console.WriteLine($"Copied {copied} file(s). Packaged {items.Count} item(s) to {outputDir}. Upload its contents to your server.");
+Console.WriteLine(string.IsNullOrEmpty(baseUrl)
+    ? "manifest.json uses file names as URLs; serve this folder or edit to full URLs."
+    : $"manifest.json URLs are prefixed with: {baseUrl}");
+Console.WriteLine("Hashes summary written to HASHES.txt");

--- a/ESP32-NF-MQTT-DHT/Tools/OtaPackager/README.md
+++ b/ESP32-NF-MQTT-DHT/Tools/OtaPackager/README.md
@@ -1,0 +1,33 @@
+# OtaPackager
+
+Small helper to prepare OTA artifacts:
+
+- copies .pe files from an input folder to an output folder
+- computes SHA256 for each .pe
+- generates manifest.json (main .pe is last)
+
+Usage
+
+```pwsh
+# Build
+dotnet build ESP32-NF-MQTT-DHT/Tools/OtaPackager/OtaPackager.csproj -c Release
+
+# Run
+# OtaPackager <inputDir> <version> <outputDir> [--main=App.pe] [--base-url=https://host/path/] [--include=App.pe;Lib.pe]
+
+# Examples
+# 1) Package all non-framework PEs from input dir, main is App.pe
+dotnet ESP32-NF-MQTT-DHT/Tools/OtaPackager/bin/Release/net8.0/OtaPackager.dll `
+	e:/path/to/ota_payload 1.0.3 e:/path/to/dist
+
+# 2) Force base URL and explicit include list
+dotnet ESP32-NF-MQTT-DHT/Tools/OtaPackager/bin/Release/net8.0/OtaPackager.dll `
+	e:/path/to/ota_payload 1.0.3 e:/path/to/dist --base-url=https://cdn.example.com/env/ --include=App.pe;Iot.Device.Something.pe
+```
+
+Notes
+
+- By default, framework PEs are skipped: mscorlib.pe, System._.pe, nanoFramework._.pe.
+- Use `--include=` to specify exact PEs if needed.
+- `--base-url` prefixes URLs in manifest.json.
+- Ensure `--main` matches device `Config.MainAppName` (default: `App.pe`).


### PR DESCRIPTION
#### PR Classification
New feature to facilitate the preparation of Over-The-Air (OTA) artifacts.

#### PR Summary
This pull request introduces the `OtaPackager` project, which enables users to copy `.pe` files, compute their SHA256 hashes, and generate a `manifest.json` for OTA updates. 
- **OtaPackager.csproj**: Added project file with configurations for building the application.
- **Program.cs**: Implemented logic to copy `.pe` files, compute hashes, and generate the manifest.
- **README.md**: Updated with usage instructions and examples for the `OtaPackager`.
- **ESP32-NF-MQTT-DHT.sln**: Added solution file for the new project.
- **OtaPackager.sln**: Created solution file for the `OtaPackager` project.
