### PR TITLE
Update .gitignore for deploy/ and FodyWeavers.xsd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,7 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Local deployment files: keep templates, ignore real device-specific configs
+deploy/*
+!deploy/*.template


### PR DESCRIPTION
Update .gitignore for deploy/ and FodyWeavers.xsd

Ignore all files in deploy/ except .template files, and add FodyWeavers.xsd to ignored files for better config and build artifact management.