### PR TITLE
Add runtime state tracking, MQTT health, and config mgmt

### DIFF
--- a/ESP32-NF-MQTT-DHT/ESP32-NF-MQTT-DHT.nfproj
+++ b/ESP32-NF-MQTT-DHT/ESP32-NF-MQTT-DHT.nfproj
@@ -35,6 +35,7 @@
     <Compile Include="ExtensionAttribute.cs" />
     <Compile Include="Helpers\CredentialCache.cs" />
     <Compile Include="Helpers\DeviceConfig.cs" />
+    <Compile Include="Helpers\RuntimeStateTracker.cs" />
     <Compile Include="Modules\Contracts\IModule.cs" />
     <Compile Include="Modules\Contracts\IModuleManager.cs" />
     <Compile Include="Modules\ModuleManager.cs" />

--- a/ESP32-NF-MQTT-DHT/Helpers/DeviceConfig.cs
+++ b/ESP32-NF-MQTT-DHT/Helpers/DeviceConfig.cs
@@ -60,6 +60,17 @@ namespace ESP32_NF_MQTT_DHT.Helpers
             }
         }
 
+        public static void Reload()
+        {
+            lock (SyncLock)
+            {
+                Values.Clear();
+                _loaded = false;
+            }
+
+            Load();
+        }
+
         public static string GetString(string key, string defaultValue = "")
         {
             if (string.IsNullOrEmpty(key))
@@ -115,6 +126,140 @@ namespace ESP32_NF_MQTT_DHT.Helpers
             }
 
             return defaultValue;
+        }
+
+        public static string GetSanitizedContent()
+        {
+            lock (SyncLock)
+            {
+                EnsureLoaded();
+
+                if (Values.Count == 0)
+                {
+                    return "No config values found.";
+                }
+
+                var sb = new StringBuilder();
+                IDictionaryEnumerator entries = (IDictionaryEnumerator)Values.GetEnumerator();
+                while (entries.MoveNext())
+                {
+                    string key = (string)entries.Key;
+                    string value = (string)entries.Value;
+
+                    sb.Append(key);
+                    sb.Append('=');
+                    sb.Append(MaskValue(key, value));
+                    sb.Append('\n');
+                }
+
+                return sb.ToString();
+            }
+        }
+
+        public static string GetSanitizedValue(string key)
+        {
+            if (string.IsNullOrEmpty(key))
+            {
+                return null;
+            }
+
+            lock (SyncLock)
+            {
+                EnsureLoaded();
+
+                if (!Values.Contains(key))
+                {
+                    return null;
+                }
+
+                return MaskValue(key, (string)Values[key]);
+            }
+        }
+
+        public static bool TrySet(string assignment, out string resultMessage)
+        {
+            resultMessage = "Invalid config assignment.";
+
+            if (string.IsNullOrEmpty(assignment))
+            {
+                return false;
+            }
+
+            int eq = assignment.IndexOf('=');
+            if (eq <= 0)
+            {
+                return false;
+            }
+
+            string key = assignment.Substring(0, eq).Trim();
+            string value = (eq + 1 < assignment.Length) ? assignment.Substring(eq + 1).Trim() : string.Empty;
+            if (key.Length == 0)
+            {
+                return false;
+            }
+
+            lock (SyncLock)
+            {
+                EnsureLoaded();
+                Values[key] = value;
+
+                try
+                {
+                    PersistValues();
+                    resultMessage = "Config updated: " + key + "=" + MaskValue(key, value);
+                    return true;
+                }
+                catch (Exception ex)
+                {
+                    resultMessage = "Failed to save config: " + ex.Message;
+                    Debug.WriteLine(resultMessage);
+                    return false;
+                }
+            }
+        }
+
+        private static void EnsureLoaded()
+        {
+            if (_loaded)
+            {
+                return;
+            }
+
+            Load();
+        }
+
+        private static void PersistValues()
+        {
+            var sb = new StringBuilder();
+            IDictionaryEnumerator entries = (IDictionaryEnumerator)Values.GetEnumerator();
+            while (entries.MoveNext())
+            {
+                sb.Append((string)entries.Key);
+                sb.Append('=');
+                sb.Append((string)entries.Value);
+                sb.Append('\n');
+            }
+
+            File.WriteAllText(ConfigPath, sb.ToString());
+        }
+
+        private static string MaskValue(string key, string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return string.Empty;
+            }
+
+            string normalizedKey = key == null ? string.Empty : key.ToLower();
+            if (normalizedKey.IndexOf("password") >= 0 ||
+                normalizedKey.IndexOf("pass") >= 0 ||
+                normalizedKey.IndexOf("secret") >= 0 ||
+                normalizedKey.IndexOf("token") >= 0)
+            {
+                return "***";
+            }
+
+            return value;
         }
 
         private static void ParseContent(string content)

--- a/ESP32-NF-MQTT-DHT/Helpers/MqttConstants.cs
+++ b/ESP32-NF-MQTT-DHT/Helpers/MqttConstants.cs
@@ -1,14 +1,26 @@
 ﻿namespace ESP32_NF_MQTT_DHT.Helpers
 {
     using System;
+    using nanoFramework.M2Mqtt.Messages;
 
     public static class MqttConstants
     {
+        public static readonly object ClientSyncRoot = new object();
+
         public static readonly string UptimeTopic = $"home/{Settings.DeviceSettings.DeviceName}/uptime";
         public static readonly string RelayTopic = $"home/{Settings.DeviceSettings.DeviceName}/switch";
         public static readonly string SystemTopic = $"home/{Settings.DeviceSettings.DeviceName}/system";
         public static readonly string SystemStatusTopic = $"home/{Settings.DeviceSettings.DeviceName}/system/status";
+        public static readonly string HeartbeatTopic = $"home/{Settings.DeviceSettings.DeviceName}/system/status/heartbeat";
+        public static readonly string WifiStatusTopic = $"home/{Settings.DeviceSettings.DeviceName}/system/status/wifi";
+        public static readonly string MqttStatusTopic = $"home/{Settings.DeviceSettings.DeviceName}/system/status/mqtt";
+        public static readonly string SensorStatusTopic = $"home/{Settings.DeviceSettings.DeviceName}/system/status/sensor";
+        public static readonly string RuntimeStatusTopic = $"home/{Settings.DeviceSettings.DeviceName}/system/status/runtime";
         public static readonly string DataTopic = $"home/{Settings.DeviceSettings.DeviceName}/messages";
         public static readonly string ErrorTopic = $"home/{Settings.DeviceSettings.DeviceName}/errors";
+
+        public const string OnlineStatusPayload = "online";
+        public const string OfflineStatusPayload = "offline";
+        public const MqttQoSLevel StatusQoS = MqttQoSLevel.AtLeastOnce;
     }
 }

--- a/ESP32-NF-MQTT-DHT/Helpers/RuntimeStateTracker.cs
+++ b/ESP32-NF-MQTT-DHT/Helpers/RuntimeStateTracker.cs
@@ -1,0 +1,274 @@
+namespace ESP32_NF_MQTT_DHT.Helpers
+{
+    using System;
+    using System.IO;
+    using System.Threading;
+
+    using ESP32_NF_MQTT_DHT.Configuration;
+    using ESP32_NF_MQTT_DHT.Services;
+
+    using nanoFramework.Runtime.Native;
+
+    /// <summary>
+    /// Tracks the latest runtime state and reboots the device if no forward progress is observed.
+    /// </summary>
+    public static class RuntimeStateTracker
+    {
+        private const string StateFilePath = @"I:\last_state.txt";
+        private const string MqttStatePrefix = "mqtt:";
+        private const int WatchdogCheckIntervalMs = 60000;
+        private const int WatchdogTimeoutMs = 600000;
+        private const int MinPersistIntervalMs = 2000;
+
+        private static readonly object _syncLock = new object();
+
+        private static bool _initialized;
+        private static bool _watchdogStarted;
+        private static string _lastState = "not-started";
+        private static DateTime _lastProgressUtc = DateTime.MinValue;
+        private static string _lastPersistedState;
+        private static DateTime _lastPersistedUtc = DateTime.MinValue;
+        private static string _lastMqttState = "mqtt:not-started";
+        private static DateTime _lastMqttProgressUtc = DateTime.MinValue;
+        private static string _previousState;
+
+        /// <summary>
+        /// Initializes the tracker and reports the previous persisted state, if available.
+        /// </summary>
+        public static void Initialize()
+        {
+            lock (_syncLock)
+            {
+                if (_initialized)
+                {
+                    return;
+                }
+
+                _initialized = true;
+            }
+
+            string previousState = TryReadLastState();
+            if (!string.IsNullOrEmpty(previousState))
+            {
+                lock (_syncLock)
+                {
+                    _previousState = previousState;
+                }
+
+                LogService.LogCritical("Previous runtime state: " + previousState);
+            }
+
+            MarkProgress("boot");
+        }
+
+        /// <summary>
+        /// Starts the watchdog thread once for the process lifetime.
+        /// </summary>
+        public static void StartWatchdog()
+        {
+            lock (_syncLock)
+            {
+                if (_watchdogStarted)
+                {
+                    return;
+                }
+
+                _watchdogStarted = true;
+            }
+
+            var watchdogThread = new Thread(WatchdogLoop);
+            watchdogThread.Start();
+        }
+
+        /// <summary>
+        /// Persists the current runtime state and updates the progress timestamp.
+        /// </summary>
+        /// <param name="state">A short state description.</param>
+        public static void MarkProgress(string state)
+        {
+            if (string.IsNullOrEmpty(state))
+            {
+                state = "unknown";
+            }
+
+            string snapshot = null;
+            lock (_syncLock)
+            {
+                _lastState = state;
+                _lastProgressUtc = DateTime.UtcNow;
+
+                if (IsMqttState(state))
+                {
+                    _lastMqttState = state;
+                    _lastMqttProgressUtc = _lastProgressUtc;
+                }
+
+                bool stateChanged = _lastPersistedState != state;
+                bool persistIntervalElapsed = _lastPersistedUtc == DateTime.MinValue ||
+                                              (_lastProgressUtc - _lastPersistedUtc).TotalMilliseconds >= MinPersistIntervalMs;
+
+                if (stateChanged || persistIntervalElapsed)
+                {
+                    snapshot = BuildSnapshot(_lastProgressUtc, _lastState);
+                    TryWriteState(snapshot);
+                    _lastPersistedState = state;
+                    _lastPersistedUtc = _lastProgressUtc;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the last persisted runtime state snapshot.
+        /// </summary>
+        /// <returns>The last persisted state, or a fallback message when unavailable.</returns>
+        public static string GetLastState()
+        {
+            lock (_syncLock)
+            {
+                if (_lastPersistedUtc != DateTime.MinValue)
+                {
+                    string persisted = TryReadLastState();
+                    if (!string.IsNullOrEmpty(persisted))
+                    {
+                        return persisted;
+                    }
+                }
+
+                if (_lastProgressUtc == DateTime.MinValue)
+                {
+                    return "No runtime state available.";
+                }
+
+                return BuildSnapshot(_lastProgressUtc, _lastState);
+            }
+        }
+
+        /// <summary>
+        /// Gets the runtime state that was persisted before the current boot.
+        /// </summary>
+        public static string GetPreviousState()
+        {
+            lock (_syncLock)
+            {
+                return string.IsNullOrEmpty(_previousState)
+                    ? "No previous runtime state available."
+                    : _previousState;
+            }
+        }
+
+        private static void WatchdogLoop()
+        {
+            while (true)
+            {
+                Thread.Sleep(WatchdogCheckIntervalMs);
+
+                string lastState;
+                DateTime lastProgressUtc;
+                string lastMqttState;
+                DateTime lastMqttProgressUtc;
+
+                lock (_syncLock)
+                {
+                    lastState = _lastState;
+                    lastProgressUtc = _lastProgressUtc;
+                    lastMqttState = _lastMqttState;
+                    lastMqttProgressUtc = _lastMqttProgressUtc;
+                }
+
+                if (lastProgressUtc == DateTime.MinValue)
+                {
+                    continue;
+                }
+
+                if ((DateTime.UtcNow - lastProgressUtc).TotalMilliseconds < WatchdogTimeoutMs)
+                {
+                    if (!IsMqttWatchdogExpired(lastMqttProgressUtc))
+                    {
+                        continue;
+                    }
+
+                    string mqttMessage = "Watchdog timeout. MQTT progress stalled. Last MQTT state: '" + lastMqttState + "' at " + lastMqttProgressUtc.ToString("u");
+                    lock (_syncLock)
+                    {
+                        string mqttSnapshot = BuildSnapshot(DateTime.UtcNow, "watchdog-timeout|mqtt-stale|" + lastMqttState);
+                        TryWriteState(mqttSnapshot);
+                        _lastPersistedState = "watchdog-timeout|mqtt-stale|" + lastMqttState;
+                        _lastPersistedUtc = DateTime.UtcNow;
+                    }
+
+                    LogService.LogCritical(mqttMessage);
+                    Thread.Sleep(1000);
+                    Power.RebootDevice();
+                    return;
+                }
+
+                string message = "Watchdog timeout. Last runtime state: '" + lastState + "' at " + lastProgressUtc.ToString("u");
+                lock (_syncLock)
+                {
+                    string snapshot = BuildSnapshot(DateTime.UtcNow, "watchdog-timeout|" + lastState);
+                    TryWriteState(snapshot);
+                    _lastPersistedState = "watchdog-timeout|" + lastState;
+                    _lastPersistedUtc = DateTime.UtcNow;
+                }
+                LogService.LogCritical(message);
+                Thread.Sleep(1000);
+                Power.RebootDevice();
+            }
+        }
+
+        private static string BuildSnapshot(DateTime timestampUtc, string state)
+        {
+            return timestampUtc.ToString("u") + " | " + state;
+        }
+
+        private static bool IsMqttState(string state)
+        {
+            return !string.IsNullOrEmpty(state) && state.IndexOf(MqttStatePrefix) == 0;
+        }
+
+        private static bool IsMqttWatchdogExpired(DateTime lastMqttProgressUtc)
+        {
+            if (!AppConfiguration.Features.EnableMqttClient)
+            {
+                return false;
+            }
+
+            if (lastMqttProgressUtc == DateTime.MinValue)
+            {
+                return false;
+            }
+
+            return (DateTime.UtcNow - lastMqttProgressUtc).TotalMilliseconds >= WatchdogTimeoutMs;
+        }
+
+        private static string TryReadLastState()
+        {
+            try
+            {
+                if (!File.Exists(StateFilePath))
+                {
+                    return null;
+                }
+
+                return File.ReadAllText(StateFilePath);
+            }
+            catch (Exception ex)
+            {
+                LogHelper.LogError("Failed to read runtime state: " + ex.Message);
+                return null;
+            }
+        }
+
+        private static void TryWriteState(string snapshot)
+        {
+            try
+            {
+                File.WriteAllText(StateFilePath, snapshot);
+            }
+            catch (Exception ex)
+            {
+                LogHelper.LogError("Failed to write runtime state: " + ex.Message);
+            }
+        }
+    }
+}

--- a/ESP32-NF-MQTT-DHT/Managers/SensorManager.cs
+++ b/ESP32-NF-MQTT-DHT/Managers/SensorManager.cs
@@ -10,6 +10,8 @@
 
     using nanoFramework.Runtime.Native;
 
+    using static ESP32_NF_MQTT_DHT.Helpers.Constants;
+
     /// <summary>
     /// Manages sensor operations including data collection and validation.
     /// </summary>
@@ -37,7 +39,12 @@
             var humidity = _sensorService.GetHumidity();
             var sensorType = _sensorService.GetSensorType();
 
-            if (!double.IsNaN(temperature) && !double.IsNaN(humidity))
+            bool validReading = !double.IsNaN(temperature) &&
+                                !double.IsNaN(humidity) &&
+                                temperature != InvalidTemperature &&
+                                humidity != InvalidHumidity;
+
+            if (validReading)
             {
                 LogHelper.LogInformation($"{sensorType} - Temp: {temperature}°C, Humidity: {humidity}%");
 
@@ -53,7 +60,7 @@
                 };
             }
 
-            LogHelper.LogWarning("Invalid data from sensors.");
+            LogHelper.LogWarning($"Invalid data from sensors. Type={sensorType}, Temp={temperature}, Humidity={humidity}");
             return null;
         }
 

--- a/ESP32-NF-MQTT-DHT/Program.cs
+++ b/ESP32-NF-MQTT-DHT/Program.cs
@@ -30,19 +30,28 @@ namespace ESP32_NF_MQTT_DHT
 #endif
             CredentialCache.Load();
             DeviceConfig.Load();
+            RuntimeStateTracker.Initialize();
+            RuntimeStateTracker.StartWatchdog();
+            RuntimeStateTracker.MarkProgress("program:config-loaded");
 
             try
             {
                 // Select sensor type from device config to avoid firmware rebuilds.
+                RuntimeStateTracker.MarkProgress("program:select-sensor-type");
                 SensorType sensorType = GetConfiguredSensorType();
 
+                RuntimeStateTracker.MarkProgress("program:configure-services");
                 var services = ConfigureServices(sensorType);
+                RuntimeStateTracker.MarkProgress("program:resolve-startup");
                 var application = services.GetService(typeof(Startup)) as Startup;
 
+                RuntimeStateTracker.MarkProgress("program:startup-run");
                 application?.Run();
+                RuntimeStateTracker.MarkProgress("program:startup-complete");
             }
             catch (Exception ex)
             {
+                RuntimeStateTracker.MarkProgress("program:main-exception");
                 LogHelper.LogError("An error occurred: " + ex.Message);
                 LogService.LogCritical("Critical error in Main", ex);
             }

--- a/ESP32-NF-MQTT-DHT/Services/InternetConnectionService.cs
+++ b/ESP32-NF-MQTT-DHT/Services/InternetConnectionService.cs
@@ -3,6 +3,7 @@ namespace ESP32_NF_MQTT_DHT.Services
     using System;
     using System.Net;
     using System.Net.Sockets;
+    using System.Threading;
 
     using ESP32_NF_MQTT_DHT.Helpers;
     using ESP32_NF_MQTT_DHT.Services.Contracts;
@@ -13,13 +14,25 @@ namespace ESP32_NF_MQTT_DHT.Services
         private static readonly IPAddress CloudflareDns = IPAddress.Parse("1.1.1.1");
 
         private const int CheckIntervalMs = 15000;
+        private const int MonitorThreadJoinTimeoutMs = 1000;
 
         private readonly object _syncLock = new object();
+        private readonly ManualResetEvent _stopSignal = new ManualResetEvent(false);
+        private readonly IConnectionService _connectionService;
+
+        private Thread _monitorThread;
 
         private bool _disposed;
         private bool _hasProbeResult;
         private bool _lastKnownInternetAvailable;
         private DateTime _lastProbeUtc = DateTime.MinValue;
+
+        public InternetConnectionService(IConnectionService connectionService)
+        {
+            _connectionService = connectionService ?? throw new ArgumentNullException(nameof(connectionService));
+            _monitorThread = new Thread(this.MonitorLoop);
+            _monitorThread.Start();
+        }
 
         public event EventHandler InternetLost;
         public event EventHandler InternetRestored;
@@ -27,6 +40,11 @@ namespace ESP32_NF_MQTT_DHT.Services
         public bool IsInternetAvailable()
         {
             ThrowIfDisposed();
+
+            if (!this.IsWifiConnected())
+            {
+                return false;
+            }
 
             lock (_syncLock)
             {
@@ -43,6 +61,8 @@ namespace ESP32_NF_MQTT_DHT.Services
 
         public void Dispose()
         {
+            Thread monitorThread = null;
+
             lock (_syncLock)
             {
                 if (_disposed)
@@ -53,9 +73,43 @@ namespace ESP32_NF_MQTT_DHT.Services
                 _disposed = true;
                 InternetLost = null;
                 InternetRestored = null;
+                monitorThread = _monitorThread;
+                _monitorThread = null;
+            }
+
+            _stopSignal.Set();
+
+            if (monitorThread != null && monitorThread.IsAlive)
+            {
+                if (!monitorThread.Join(MonitorThreadJoinTimeoutMs))
+                {
+                    LogHelper.LogWarning("Internet monitor thread did not terminate within timeout.");
+                }
             }
 
             LogHelper.LogInformation("InternetConnectionService disposed.");
+        }
+
+        private void MonitorLoop()
+        {
+            while (true)
+            {
+                if (this.IsDisposed())
+                {
+                    return;
+                }
+
+                if (this.IsWifiConnected())
+                {
+                    bool isAvailable = this.TryCheckInternet();
+                    this.UpdateInternetState(isAvailable);
+                }
+
+                if (_stopSignal.WaitOne(CheckIntervalMs, false))
+                {
+                    return;
+                }
+            }
         }
 
         private bool TryCheckInternet()
@@ -153,6 +207,26 @@ namespace ESP32_NF_MQTT_DHT.Services
                 {
                     throw new ObjectDisposedException(nameof(InternetConnectionService));
                 }
+            }
+        }
+
+        private bool IsDisposed()
+        {
+            lock (_syncLock)
+            {
+                return _disposed;
+            }
+        }
+
+        private bool IsWifiConnected()
+        {
+            try
+            {
+                return _connectionService.IsConnected;
+            }
+            catch
+            {
+                return false;
             }
         }
     }

--- a/ESP32-NF-MQTT-DHT/Services/MQTT/Contracts/IMqttPublishService.cs
+++ b/ESP32-NF-MQTT-DHT/Services/MQTT/Contracts/IMqttPublishService.cs
@@ -1,5 +1,7 @@
 ﻿namespace ESP32_NF_MQTT_DHT.Services.MQTT.Contracts
 {
+    using System;
+
     using nanoFramework.M2Mqtt;
 
     /// <summary>
@@ -7,6 +9,11 @@
     /// </summary>
     public interface IMqttPublishService
     {
+        /// <summary>
+        /// Raised when a publish attempt indicates that the MQTT connection is unhealthy.
+        /// </summary>
+        event EventHandler PublishFailed;
+
         /// <summary>
         /// Publishes sensor data to the MQTT broker.
         /// </summary>
@@ -17,6 +24,11 @@
         /// </summary>
         /// <param name="errorMessage">The error message to be published.</param>
         void PublishError(string errorMessage);
+
+        /// <summary>
+        /// Publishes boot and runtime diagnostics after an MQTT connection is initialized.
+        /// </summary>
+        void PublishRuntimeDiagnostics();
 
         /// <summary>
         /// Sets the MQTT client to be used for publishing messages.

--- a/ESP32-NF-MQTT-DHT/Services/MQTT/MqttConnectionManager.cs
+++ b/ESP32-NF-MQTT-DHT/Services/MQTT/MqttConnectionManager.cs
@@ -7,9 +7,14 @@
     using ESP32_NF_MQTT_DHT.Services.MQTT.Contracts;
 
     using nanoFramework.M2Mqtt;
+    using nanoFramework.M2Mqtt.Messages;
+
+    using static Settings.MqttSettings;
 
     internal class MqttConnectionManager : IMqttConnectionManager
     {
+        private const ushort KeepAliveSeconds = 60;
+
         /// <summary>
         /// Gets the MQTT client.
         /// </summary>
@@ -24,8 +29,34 @@
             {
                 LogHelper.LogInformation($"Connecting to MQTT broker: {broker}:{port} (TLS: {useTls})...");
                 var sslProtocol = useTls ? MqttSslProtocols.TLSv1_2 : MqttSslProtocols.None;
-                this.MqttClient = new MqttClient(broker, port, useTls, null, null, sslProtocol);
-                this.MqttClient.Connect(clientId, user, pass);
+
+                lock (MqttConstants.ClientSyncRoot)
+                {
+                    LogHelper.LogInformation("Creating MQTT client instance...");
+                    this.MqttClient = new MqttClient(broker, port, useTls, null, null, sslProtocol);
+                    LogHelper.LogInformation("MQTT client instance created.");
+
+                    if (UseLastWill)
+                    {
+                        LogHelper.LogInformation("Connecting MQTT client with Last Will enabled...");
+                        this.MqttClient.Connect(
+                            clientId,
+                            user,
+                            pass,
+                            true,
+                            MqttConstants.StatusQoS,
+                            true,
+                            MqttConstants.SystemStatusTopic,
+                            MqttConstants.OfflineStatusPayload,
+                            true,
+                            KeepAliveSeconds);
+                    }
+                    else
+                    {
+                        LogHelper.LogInformation("Connecting MQTT client with simple auth/keepalive path...");
+                        this.MqttClient.Connect(clientId, user, pass, true, KeepAliveSeconds);
+                    }
+                }
 
                 if (this.MqttClient.IsConnected)
                 {
@@ -55,12 +86,15 @@
             {
                 try
                 {
-                    if (this.MqttClient.IsConnected)
+                    lock (MqttConstants.ClientSyncRoot)
                     {
-                        this.MqttClient.Disconnect();
-                    }
+                        if (this.MqttClient.IsConnected)
+                        {
+                            this.MqttClient.Disconnect();
+                        }
 
-                    this.MqttClient.Dispose();
+                        this.MqttClient.Dispose();
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/ESP32-NF-MQTT-DHT/Services/MQTT/MqttMessageHandler.cs
+++ b/ESP32-NF-MQTT-DHT/Services/MQTT/MqttMessageHandler.cs
@@ -57,7 +57,8 @@
             try
             {
                 var message = Encoding.UTF8.GetString(e.Message, 0, e.Message.Length);
-                var command = NormalizeMessage(message);
+                var trimmedMessage = string.IsNullOrEmpty(message) ? string.Empty : message.Trim();
+                var command = NormalizeMessage(trimmedMessage);
 
                 if (e.Topic == MqttConstants.RelayTopic)
                 {
@@ -126,6 +127,63 @@
                         this.Publish(MqttConstants.SystemTopic + "/logs", logs);
                         LogHelper.LogInformation("Logs requested, published");
                     }
+                    else if (command == "getstate")
+                    {
+                        string state = "previous=" + RuntimeStateTracker.GetPreviousState() +
+                                       "\ncurrent=" + RuntimeStateTracker.GetLastState();
+                        this.Publish(MqttConstants.SystemTopic + "/state", state);
+                        LogHelper.LogInformation("Runtime state requested, published");
+                    }
+                    else if (command == "getconfig")
+                    {
+                        string config = DeviceConfig.GetSanitizedContent();
+                        this.Publish(MqttConstants.SystemTopic + "/config", config);
+                        LogHelper.LogInformation("Config requested, published");
+                    }
+                    else if (command.StartsWith("getconfig "))
+                    {
+                        string key = trimmedMessage.Substring("getconfig ".Length).Trim();
+                        string value = DeviceConfig.GetSanitizedValue(key);
+                        this.Publish(MqttConstants.SystemTopic + "/config", value == null ? "Config key not found: " + key : key + "=" + value);
+                        LogHelper.LogInformation("Config value requested, published");
+                    }
+                    else if (command.StartsWith("setconfig "))
+                    {
+                        string assignment = trimmedMessage.Substring("setconfig ".Length).Trim();
+                        bool updated = DeviceConfig.TrySet(assignment, out string result);
+                        this.Publish(MqttConstants.SystemTopic + "/config", result);
+                        LogHelper.LogInformation(updated ? "Config updated via MQTT" : "Config update via MQTT failed");
+                    }
+                    else if (command == "reloadconfig")
+                    {
+                        DeviceConfig.Reload();
+                        this.Publish(MqttConstants.SystemTopic + "/config", "Config reloaded");
+                        LogHelper.LogInformation("Config reloaded via MQTT");
+                    }
+                    else if (command == "reconnectmqtt")
+                    {
+                        this.Publish(MqttConstants.SystemTopic + "/reconnect", "MQTT reconnect requested");
+                        LogHelper.LogInformation("MQTT reconnect requested via MQTT command");
+
+                        lock (MqttConstants.ClientSyncRoot)
+                        {
+                            if (_mqttClient != null && _mqttClient.IsConnected)
+                            {
+                                _mqttClient.Disconnect();
+                            }
+                        }
+                    }
+                    else if (command == "reconnectwifi")
+                    {
+                        _connectionService.CheckConnection();
+
+                        string wifiResult = _connectionService.IsConnected
+                            ? "WiFi connected: " + _connectionService.GetIpAddress()
+                            : "WiFi reconnect requested, still disconnected";
+
+                        this.Publish(MqttConstants.SystemTopic + "/wifi", wifiResult);
+                        LogHelper.LogInformation("WiFi reconnect requested via MQTT command");
+                    }
                     else if (command == "clearlogs")
                     {
                         LogService.ClearLogs();
@@ -150,12 +208,20 @@
 
         private void Publish(string topic, string payload)
         {
-            if (_mqttClient == null || !_mqttClient.IsConnected || string.IsNullOrEmpty(topic) || payload == null)
+            if (string.IsNullOrEmpty(topic) || payload == null)
             {
                 return;
             }
 
-            _mqttClient.Publish(topic, Encoding.UTF8.GetBytes(payload));
+            lock (MqttConstants.ClientSyncRoot)
+            {
+                if (_mqttClient == null || !_mqttClient.IsConnected)
+                {
+                    return;
+                }
+
+                _mqttClient.Publish(topic, Encoding.UTF8.GetBytes(payload));
+            }
         }
 
         private static string NormalizeMessage(string message)

--- a/ESP32-NF-MQTT-DHT/Services/MQTT/MqttPublishService.cs
+++ b/ESP32-NF-MQTT-DHT/Services/MQTT/MqttPublishService.cs
@@ -8,9 +8,14 @@
     using ESP32_NF_MQTT_DHT.Managers.Contracts;
     using ESP32_NF_MQTT_DHT.Services.Contracts;
     using ESP32_NF_MQTT_DHT.Services.MQTT.Contracts;
+    using ESP32_NF_MQTT_DHT.Settings;
 
     using nanoFramework.Json;
     using nanoFramework.M2Mqtt;
+    using nanoFramework.M2Mqtt.Messages;
+    using GC = nanoFramework.Runtime.Native.GC;
+
+    using static ESP32_NF_MQTT_DHT.Helpers.Constants;
 
     /// <summary>
     /// Service responsible for publishing sensor data and error messages to an MQTT broker.
@@ -18,29 +23,45 @@
     public class MqttPublishService : IMqttPublishService, IDisposable
     {
         private const int HeartbeatInterval = 30000;
+        private const int InitialHeartbeatDelayMs = 5000;
         private readonly ManualResetEvent _heartbeatStopSignal = new ManualResetEvent(false);
         private readonly object _heartbeatLock = new object();
         private readonly object _clientLock = new object();
         private readonly object _runningLock = new object();
+        private readonly object _publishFailureLock = new object();
         
         private readonly ISensorManager _sensorManager;
         private readonly IInternetConnectionService _internetConnectionService;
+        private readonly IConnectionService _connectionService;
+        private readonly IUptimeService _uptimeService;
+        private readonly ISensorService _sensorService;
         
         private MqttClient _mqttClient;
         private Thread _heartbeatThread;
         
         private bool _isHeartbeatRunning = false;
         private bool _disposed = false;
+        private bool _publishFailureReported;
+
+        public event EventHandler PublishFailed;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MqttPublishService"/> class.
         /// </summary>
         /// <param name="internetConnectionService">The internet connection service for checking internet availability.</param>
         /// <param name="sensorManager">The sensor manager for retrieving sensor data.</param>
-        public MqttPublishService(IInternetConnectionService internetConnectionService, ISensorManager sensorManager)
+        public MqttPublishService(
+            IInternetConnectionService internetConnectionService,
+            ISensorManager sensorManager,
+            IConnectionService connectionService,
+            IUptimeService uptimeService,
+            ISensorService sensorService)
         {
             _internetConnectionService = internetConnectionService ?? throw new ArgumentNullException(nameof(internetConnectionService));
             _sensorManager = sensorManager ?? throw new ArgumentNullException(nameof(sensorManager));
+            _connectionService = connectionService ?? throw new ArgumentNullException(nameof(connectionService));
+            _uptimeService = uptimeService ?? throw new ArgumentNullException(nameof(uptimeService));
+            _sensorService = sensorService ?? throw new ArgumentNullException(nameof(sensorService));
         }
 
         /// <summary>
@@ -54,6 +75,11 @@
             lock (_clientLock)
             {
                 _mqttClient = mqttClient;
+            }
+
+            lock (_publishFailureLock)
+            {
+                _publishFailureReported = false;
             }
         }
 
@@ -79,9 +105,18 @@
                 {
                     try
                     {
+                        RuntimeStateTracker.MarkProgress("mqtt:heartbeat-thread-start");
+
+                        if (_heartbeatStopSignal.WaitOne(InitialHeartbeatDelayMs, false))
+                        {
+                            return;
+                        }
+
                         while (_isHeartbeatRunning && !_disposed)
                         {
-                            PublishDeviceStatus();
+                            RuntimeStateTracker.MarkProgress("mqtt:heartbeat-publish-start");
+                            this.PublishPeriodicStatus();
+                            RuntimeStateTracker.MarkProgress("mqtt:heartbeat-publish-complete");
                             
                             if (_heartbeatStopSignal.WaitOne(HeartbeatInterval, false))
                             {
@@ -152,7 +187,7 @@
                 if (data != null)
                 {
                     var message = JsonSerializer.SerializeObject(data);
-                    this.CheckInternetAndPublish(MqttConstants.DataTopic, message);
+                    this.TryPublishMessage(MqttConstants.DataTopic, message, MqttQoSLevel.AtLeastOnce, false, true, "sensor data");
                 }
                 else
                 {
@@ -192,11 +227,45 @@
                     return;
                 }
 
-                this.CheckInternetAndPublish(MqttConstants.ErrorTopic, errorMessage);
+                this.TryPublishMessage(MqttConstants.ErrorTopic, errorMessage, MqttQoSLevel.AtLeastOnce, false, true, "error message");
             }
             catch (Exception ex)
             {
                 LogHelper.LogError($"Error publishing error message: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Publishes the state that survived the previous boot so short reconnect windows remain diagnosable.
+        /// </summary>
+        public void PublishRuntimeDiagnostics()
+        {
+            lock (_runningLock)
+            {
+                if (_disposed) return;
+            }
+
+            try
+            {
+                string payload = "boot; uptime=" + _uptimeService.GetUptime() +
+                                 "; freeMemory=" + GC.Run(false) +
+                                 "; previousState=" + RuntimeStateTracker.GetPreviousState() +
+                                 "; currentState=" + RuntimeStateTracker.GetLastState();
+
+                if (this.TryPublishMessage(
+                    MqttConstants.RuntimeStatusTopic,
+                    payload,
+                    MqttConstants.StatusQoS,
+                    true,
+                    false,
+                    "runtime diagnostics"))
+                {
+                    LogHelper.LogInformation("Runtime diagnostics published.");
+                }
+            }
+            catch (Exception ex)
+            {
+                LogHelper.LogError("Error publishing runtime diagnostics: " + ex.Message);
             }
         }
 
@@ -224,6 +293,11 @@
                 {
                     _mqttClient = null;
                 }
+
+                lock (_publishFailureLock)
+                {
+                    PublishFailed = null;
+                }
                 
                 LogHelper.LogInformation("MqttPublishService disposed.");
             }
@@ -234,9 +308,9 @@
         }
 
         /// <summary>
-        /// Publishes the device status to the MQTT broker.
+        /// Publishes device health and subsystem statuses to the MQTT broker.
         /// </summary>
-        private void PublishDeviceStatus()
+        private void PublishPeriodicStatus()
         {
             lock (_runningLock)
             {
@@ -245,27 +319,30 @@
             
             try
             {
-                MqttClient client;
-                lock (_clientLock)
+                if (!this.TryPublishMessage(MqttConstants.SystemStatusTopic, MqttConstants.OnlineStatusPayload, MqttConstants.StatusQoS, true, true, "system status"))
                 {
-                    client = _mqttClient;
-                }
-
-                if (client == null)
-                {
-                    LogHelper.LogWarning("Heartbeat skipped: MQTT client is null.");
                     return;
                 }
 
-                if (!client.IsConnected)
+                if (!this.TryPublishMessage(MqttConstants.MqttStatusTopic, this.BuildMqttStatusPayload(), MqttConstants.StatusQoS, true, true, "mqtt status"))
                 {
-                    LogHelper.LogWarning("Heartbeat skipped: MQTT client is not connected.");
                     return;
                 }
 
-                string message = "online";
-                client.Publish(MqttConstants.SystemStatusTopic, Encoding.UTF8.GetBytes(message));
-                LogHelper.LogInformation($"Heartbeat sent: {message}");
+                if (!this.TryPublishMessage(MqttConstants.WifiStatusTopic, this.BuildWifiStatusPayload(), MqttConstants.StatusQoS, true, true, "wifi status"))
+                {
+                    return;
+                }
+
+                if (!this.TryPublishMessage(MqttConstants.SensorStatusTopic, this.BuildSensorStatusPayload(), MqttConstants.StatusQoS, true, true, "sensor status"))
+                {
+                    return;
+                }
+
+                if (this.TryPublishMessage(MqttConstants.HeartbeatTopic, this.BuildHeartbeatPayload(), MqttConstants.StatusQoS, false, true, "heartbeat"))
+                {
+                    LogHelper.LogInformation("Heartbeat sent.");
+                }
             }
             catch (Exception ex)
             {
@@ -274,15 +351,13 @@
         }
 
         /// <summary>
-        /// Checks internet availability and publishes a message to the specified topic.
+        /// Publishes a message to the specified topic and reports failures as MQTT health issues.
         /// </summary>
-        /// <param name="topic">The topic to publish the message to.</param>
-        /// <param name="message">The message to be published.</param>
-        private void CheckInternetAndPublish(string topic, string message)
+        private bool TryPublishMessage(string topic, string message, MqttQoSLevel qosLevel, bool retain, bool raiseFailureOnError, string context)
         {
             lock (_runningLock)
             {
-                if (_disposed) return;
+                if (_disposed) return false;
             }
             
             try
@@ -293,17 +368,114 @@
                     client = _mqttClient;
                 }
 
-                if (client == null || !client.IsConnected)
+                lock (MqttConstants.ClientSyncRoot)
                 {
-                    LogHelper.LogWarning("MQTT client is not connected.");
-                    return;
+                    if (client == null || !client.IsConnected)
+                    {
+                        LogHelper.LogWarning("MQTT publish skipped because the client is not connected. Context: " + context);
+                        if (raiseFailureOnError)
+                        {
+                            this.ReportPublishFailure();
+                        }
+
+                        return false;
+                    }
+
+                    client.Publish(topic, Encoding.UTF8.GetBytes(message), null, null, qosLevel, retain);
                 }
 
-                client.Publish(topic, Encoding.UTF8.GetBytes(message));
+                lock (_publishFailureLock)
+                {
+                    _publishFailureReported = false;
+                }
+
+                return true;
             }
             catch (Exception ex)
             {
-                LogHelper.LogError($"Error in CheckInternetAndPublish: {ex.Message}");
+                LogHelper.LogError($"Error publishing {context}: {ex.Message}");
+                if (raiseFailureOnError)
+                {
+                    this.ReportPublishFailure();
+                }
+
+                return false;
+            }
+        }
+
+        private string BuildHeartbeatPayload()
+        {
+            string wifiState = _connectionService.IsConnected ? "connected" : "disconnected";
+            string sensorState = this.IsSensorReadingValid(_sensorService.GetTemp(), _sensorService.GetHumidity()) ? "ok" : "invalid";
+
+            return "alive; uptime=" + _uptimeService.GetUptime() +
+                   "; freeMemory=" + GC.Run(false) +
+                   "; wifi=" + wifiState +
+                   "; mqtt=connected" +
+                   "; sensor=" + sensorState;
+        }
+
+        private string BuildWifiStatusPayload()
+        {
+            if (!_connectionService.IsConnected)
+            {
+                return "disconnected";
+            }
+
+            return "connected; ip=" + _connectionService.GetIpAddress();
+        }
+
+        private string BuildMqttStatusPayload()
+        {
+            return "connected; clientId=" + Settings.MqttSettings.ClientId;
+        }
+
+        private string BuildSensorStatusPayload()
+        {
+            double temperature = _sensorService.GetTemp();
+            double humidity = _sensorService.GetHumidity();
+            string sensorType = _sensorService.GetSensorType();
+
+            if (!this.IsSensorReadingValid(temperature, humidity))
+            {
+                return "invalid; type=" + sensorType;
+            }
+
+            double roundedTemp = Math.Round(temperature * 100) / 100;
+            double roundedHumidity = Math.Round(humidity * 100) / 100;
+            return "ok; type=" + sensorType + "; temp=" + roundedTemp + "; humidity=" + roundedHumidity;
+        }
+
+        private bool IsSensorReadingValid(double temperature, double humidity)
+        {
+            return !double.IsNaN(temperature) &&
+                   !double.IsNaN(humidity) &&
+                   temperature != InvalidTemperature &&
+                   humidity != InvalidHumidity;
+        }
+
+        private void ReportPublishFailure()
+        {
+            EventHandler handler = null;
+
+            lock (_publishFailureLock)
+            {
+                if (_publishFailureReported || _disposed)
+                {
+                    return;
+                }
+
+                _publishFailureReported = true;
+                handler = PublishFailed;
+            }
+
+            try
+            {
+                handler?.Invoke(this, EventArgs.Empty);
+            }
+            catch (Exception ex)
+            {
+                LogHelper.LogError("Error raising PublishFailed event: " + ex.Message);
             }
         }
 

--- a/ESP32-NF-MQTT-DHT/Services/MqttClientService.cs
+++ b/ESP32-NF-MQTT-DHT/Services/MqttClientService.cs
@@ -25,7 +25,7 @@
     internal class MqttClientService : IMqttClientService, IDisposable
     {
         private const int ConnectionThreadJoinTimeoutMs = 1000;
-        private const int DeepSleepWaitMs = 2000;
+        private const int InitialPostConnectPublishDelayMs = 5000;
         private const string WifiSource = "WiFi";
         private const string InternetSource = "Internet";
 
@@ -46,15 +46,18 @@
         private readonly object _randomLock = new object();
         private readonly object _heartbeatLock = new object();
         private readonly object _disconnectReasonLock = new object();
+        private readonly object _mqttHealthLock = new object();
 
         private bool _isRunning;
         private bool _isHeartbeatRunning;
         private bool _isDisposed;
+        private bool _mqttHealthFailed;
 
         private EventHandler _internetLostHandler;
         private EventHandler _internetRestoredHandler;
         private EventHandler _connectionLostHandler;
         private EventHandler _connectionRestoredHandler;
+        private EventHandler _publishFailedHandler;
 
         private Thread _workerThread;
 
@@ -81,11 +84,13 @@
             _internetRestoredHandler = (s, e) => this.OnConnectivityChanged(s, true, InternetSource);
             _connectionLostHandler = (s, e) => this.OnConnectivityChanged(s, false, WifiSource);
             _connectionRestoredHandler = (s, e) => this.OnConnectivityChanged(s, true, WifiSource);
+            _publishFailedHandler = (s, e) => this.OnPublishFailed();
 
             _internetConnectionService.InternetLost += _internetLostHandler;
             _internetConnectionService.InternetRestored += _internetRestoredHandler;
             _connectionService.ConnectionLost += _connectionLostHandler;
             _connectionService.ConnectionRestored += _connectionRestoredHandler;
+            _mqttPublishService.PublishFailed += _publishFailedHandler;
 
             this.SetIsRunning(true);
 
@@ -130,6 +135,24 @@
             }
 
             _wakeSignal.Set();
+        }
+
+        private bool IsWorkerRunning()
+        {
+            lock (_connectionLock)
+            {
+                return _workerThread != null && _workerThread.IsAlive;
+            }
+        }
+
+        private void WakeWorkerOrStart()
+        {
+            _wakeSignal.Set();
+
+            if (!this.IsWorkerRunning())
+            {
+                this.Start();
+            }
         }
 
         /// <summary>
@@ -184,6 +207,11 @@
                     _connectionService.ConnectionRestored -= _connectionRestoredHandler;
                 }
 
+                if (_mqttPublishService != null)
+                {
+                    _mqttPublishService.PublishFailed -= _publishFailedHandler;
+                }
+
                 if (MqttClient != null)
                 {
                     MqttClient.ConnectionClosed -= ConnectionClosed;
@@ -194,6 +222,7 @@
                 _internetRestoredHandler = null;
                 _connectionLostHandler = null;
                 _connectionRestoredHandler = null;
+                _publishFailedHandler = null;
             }
             catch (Exception ex)
             {
@@ -214,11 +243,13 @@
             int attemptCount = 0;
             int reconnectDelay = InitialReconnectDelayMs;
             DateTime nextSensorPublish = DateTime.UtcNow;
+            RuntimeStateTracker.MarkProgress("mqtt:loop-start");
 
             while (this.GetIsRunning())
             {
                 if (_circuitBreaker.IsOpen)
                 {
+                    RuntimeStateTracker.MarkProgress("mqtt:circuit-breaker-open");
                     LogHelper.LogWarning("Circuit breaker open. Waiting before retrying MQTT connection.");
                     if (this.WaitForWake(reconnectDelay))
                     {
@@ -228,7 +259,9 @@
                     continue;
                 }
 
+                RuntimeStateTracker.MarkProgress("mqtt:before-wifi-check");
                 bool wifiReady = this.EnsureWifiConnected();
+                RuntimeStateTracker.MarkProgress(wifiReady ? "mqtt:wifi-ready" : "mqtt:wifi-not-ready");
 
                 if (!wifiReady)
                 {
@@ -244,17 +277,20 @@
 
                 if (!this.IsMqttReady())
                 {
+                    RuntimeStateTracker.MarkProgress("mqtt:before-connect");
                     if (this.AttemptBrokerConnection())
                     {
+                        RuntimeStateTracker.MarkProgress("mqtt:connected");
                         LogHelper.LogInformation("Connected to MQTT broker.");
                         LogHelper.LogInformation($"MQTT reconnect diagnostics: last disconnect reason='{this.GetLastDisconnectReason()}', free memory={GC.Run(false)} bytes");
                         attemptCount = 0;
                         reconnectDelay = InitialReconnectDelayMs;
-                        nextSensorPublish = DateTime.UtcNow;
+                        nextSensorPublish = DateTime.UtcNow.AddMilliseconds(InitialPostConnectPublishDelayMs);
                         continue;
                     }
 
                     attemptCount++;
+                    RuntimeStateTracker.MarkProgress("mqtt:connect-failed");
                     LogHelper.LogWarning($"MQTT connection failed (attempt {attemptCount}/{MaxTotalAttempts}).");
 
                     if (attemptCount >= MaxTotalAttempts)
@@ -277,7 +313,9 @@
 
                 if (DateTime.UtcNow >= nextSensorPublish)
                 {
+                    RuntimeStateTracker.MarkProgress("mqtt:before-publish");
                     this.PublishSensorData();
+                    RuntimeStateTracker.MarkProgress("mqtt:after-publish");
                     nextSensorPublish = DateTime.UtcNow.AddMilliseconds(SensorDataIntervalMs);
                 }
 
@@ -318,16 +356,9 @@
         /// </summary>
         private void HandleMaxAttemptsReached()
         {
-            LogHelper.LogWarning("Entering deep sleep to conserve power");
-
+            RuntimeStateTracker.MarkProgress("mqtt:max-attempts-reached");
+            LogHelper.LogWarning("Maximum MQTT reconnect attempts reached. Keeping device awake and continuing with circuit-breaker backoff.");
             this.SafeDisconnect("Maximum reconnect attempts reached");
-
-            _stopSignal.WaitOne(DeepSleepWaitMs, false);
-
-            TimeSpan deepSleepDuration = new TimeSpan(0, DeepSleepMinutes, 0);
-
-            Sleep.EnableWakeupByTimer(deepSleepDuration);
-            Sleep.StartDeepSleep();
         }
 
         /// <summary>
@@ -336,14 +367,18 @@
         /// </summary>
         private bool AttemptBrokerConnection()
         {
-            this.SafeDisconnect();
+            RuntimeStateTracker.MarkProgress("mqtt:connect-disconnect-old-client");
+            this.SafeDisconnect("Preparing fresh MQTT connection");
 
             try
             {
+                RuntimeStateTracker.MarkProgress("mqtt:connect-call");
                 bool isConnected = _connectionManager.Connect(Broker, Port, UseTls, ClientId, ClientUsername, ClientPassword);
 
                 if (isConnected && this.MqttClient != null && this.MqttClient.IsConnected)
                 {
+                    RuntimeStateTracker.MarkProgress("mqtt:initialize-client");
+                    this.SetMqttHealthy(true);
                     this.InitializeMqttClient();
                     return true;
                 }
@@ -364,7 +399,8 @@
                 LogService.LogCritical($"MQTT connect error: {ex.Message}\n{ex}");
             }
 
-            this.SafeDisconnect();
+            RuntimeStateTracker.MarkProgress("mqtt:connect-cleanup");
+            this.SafeDisconnect("MQTT connect cleanup");
             return false;
         }
 
@@ -373,23 +409,29 @@
         /// </summary>
         private void InitializeMqttClient()
         {
+            RuntimeStateTracker.MarkProgress("mqtt:initialize-client-start");
             if (this.MqttClient == null)
             {
                 LogHelper.LogError("Cannot initialize null MQTT client");
                 return;
             }
 
-            this.MqttClient.ConnectionClosed -= this.ConnectionClosed;
-            this.MqttClient.MqttMsgPublishReceived -= _mqttMessageHandler.HandleIncomingMessage;
+            lock (MqttConstants.ClientSyncRoot)
+            {
+                this.MqttClient.ConnectionClosed -= this.ConnectionClosed;
+                this.MqttClient.MqttMsgPublishReceived -= _mqttMessageHandler.HandleIncomingMessage;
 
-            this.MqttClient.ConnectionClosed += this.ConnectionClosed;
-            this.MqttClient.Subscribe(
-                new[] { MqttConstants.RelayTopic, MqttConstants.SystemTopic, OTA.Config.TopicCmd },
-                new[] { MqttQoSLevel.AtLeastOnce, MqttQoSLevel.AtLeastOnce, MqttQoSLevel.AtLeastOnce });
-            this.MqttClient.MqttMsgPublishReceived += _mqttMessageHandler.HandleIncomingMessage;
+                this.MqttClient.ConnectionClosed += this.ConnectionClosed;
+                this.MqttClient.Subscribe(
+                    new[] { MqttConstants.RelayTopic, MqttConstants.SystemTopic, OTA.Config.TopicCmd },
+                    new[] { MqttQoSLevel.AtLeastOnce, MqttQoSLevel.AtLeastOnce, MqttQoSLevel.AtLeastOnce });
+                this.MqttClient.MqttMsgPublishReceived += _mqttMessageHandler.HandleIncomingMessage;
+            }
 
             _mqttMessageHandler.SetMqttClient(this.MqttClient);
             _mqttPublishService.SetMqttClient(this.MqttClient);
+            this.SetMqttHealthy(true);
+            _mqttPublishService.PublishRuntimeDiagnostics();
 
             lock (_heartbeatLock)
             {
@@ -401,6 +443,7 @@
             }
 
             LogHelper.LogInformation("MQTT client setup complete");
+            RuntimeStateTracker.MarkProgress("mqtt:initialize-client-complete");
         }
 
         /// <summary>
@@ -421,8 +464,7 @@
                 if (isRestored)
                 {
                     LogHelper.LogInformation("WiFi restored.");
-                    _wakeSignal.Set();
-                    this.Start();
+                    this.WakeWorkerOrStart();
                 }
                 else
                 {
@@ -440,9 +482,8 @@
 
                     if (_connectionService.IsConnected)
                     {
-                        LogHelper.LogInformation("WiFi is now detected as connected, starting MQTT...");
-                        _wakeSignal.Set();
-                        this.Start();
+                        LogHelper.LogInformation("WiFi is now detected as connected, waking MQTT worker...");
+                        this.WakeWorkerOrStart();
                     }
                     else
                     {
@@ -454,9 +495,13 @@
 
                 if (isRestored)
                 {
+                    if (this.IsMqttReady())
+                    {
+                        return;
+                    }
+
                     LogHelper.LogInformation("Internet restored.");
-                    _wakeSignal.Set();
-                    this.Start();
+                    this.WakeWorkerOrStart();
                 }
                 else
                 {
@@ -478,7 +523,26 @@
 
             LogHelper.LogWarning("Lost connection to MQTT broker, attempting to reconnect...");
 
+            this.SetMqttHealthy(false);
             this.SafeDisconnect("MQTT broker closed connection");
+            _wakeSignal.Set();
+        }
+
+        private void OnPublishFailed()
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            if (this.GetMqttHealthFailed())
+            {
+                return;
+            }
+
+            LogHelper.LogWarning("MQTT publish health check failed. Scheduling reconnect.");
+            this.SetLastDisconnectReason("MQTT publish health check failed");
+            this.SetMqttHealthy(false);
             _wakeSignal.Set();
         }
 
@@ -509,7 +573,7 @@
             }
 
             var client = _connectionManager.MqttClient;
-            return client != null && client.IsConnected;
+            return !this.GetMqttHealthFailed() && client != null && client.IsConnected;
         }
 
         private int GetJitter()
@@ -552,6 +616,7 @@
             {
                 long memoryBeforePublish = GC.Run(false);
                 LogHelper.LogInformation($"Publish diagnostics: free memory before publish={memoryBeforePublish} bytes");
+                RuntimeStateTracker.MarkProgress("mqtt:publish-dispatch");
                 _mqttPublishService.PublishSensorData();
                 long memoryAfterPublish = GC.Run(false);
                 LogHelper.LogInformation($"Publish diagnostics: free memory after publish={memoryAfterPublish} bytes");
@@ -585,18 +650,24 @@
         {
             var client = _connectionManager.MqttClient;
             this.SetLastDisconnectReason(reason);
-
-            LogHelper.LogWarning($"MQTT disconnect diagnostics: reason='{reason}', free memory={GC.Run(false)} bytes");
+            this.SetMqttHealthy(false);
 
             if (client == null)
             {
                 return;
             }
 
+            RuntimeStateTracker.MarkProgress("mqtt:disconnect|" + reason);
+
+            LogHelper.LogWarning($"MQTT disconnect diagnostics: reason='{reason}', free memory={GC.Run(false)} bytes");
+
             try
             {
-                client.ConnectionClosed -= this.ConnectionClosed;
-                client.MqttMsgPublishReceived -= _mqttMessageHandler.HandleIncomingMessage;
+                lock (MqttConstants.ClientSyncRoot)
+                {
+                    client.ConnectionClosed -= this.ConnectionClosed;
+                    client.MqttMsgPublishReceived -= _mqttMessageHandler.HandleIncomingMessage;
+                }
             }
             catch (Exception ex)
             {
@@ -612,6 +683,22 @@
 
                 _mqttPublishService.StopHeartbeat();
                 _connectionManager.Disconnect();
+            }
+        }
+
+        private bool GetMqttHealthFailed()
+        {
+            lock (_mqttHealthLock)
+            {
+                return _mqttHealthFailed;
+            }
+        }
+
+        private void SetMqttHealthy(bool isHealthy)
+        {
+            lock (_mqttHealthLock)
+            {
+                _mqttHealthFailed = !isHealthy;
             }
         }
 

--- a/ESP32-NF-MQTT-DHT/Services/OtaService.cs
+++ b/ESP32-NF-MQTT-DHT/Services/OtaService.cs
@@ -42,15 +42,17 @@ namespace ESP32_NF_MQTT_DHT.Services
         {
             try
             {
-                if (_mqttClient != null && _mqttClient.IsConnected)
+                lock (Helpers.MqttConstants.ClientSyncRoot)
                 {
-                    var json = OtaUtil.StatusJson(state, msg);
-                    _mqttClient.Publish(ESP32_NF_MQTT_DHT.OTA.Config.TopicStatus, System.Text.Encoding.UTF8.GetBytes(json));
+                    if (_mqttClient != null && _mqttClient.IsConnected)
+                    {
+                        var json = OtaUtil.StatusJson(state, msg);
+                        _mqttClient.Publish(ESP32_NF_MQTT_DHT.OTA.Config.TopicStatus, System.Text.Encoding.UTF8.GetBytes(json));
+                        return;
+                    }
                 }
-                else
-                {
-                    OtaUtil.SafeStatus(state, msg);
-                }
+
+                OtaUtil.SafeStatus(state, msg);
             }
             catch
             {

--- a/ESP32-NF-MQTT-DHT/Services/Sensors/BaseSensorService.cs
+++ b/ESP32-NF-MQTT-DHT/Services/Sensors/BaseSensorService.cs
@@ -60,6 +60,7 @@
         public virtual void Start()
         {
             _running = true;
+            RuntimeStateTracker.MarkProgress("sensor:start|" + this.GetSensorType());
             _readTimer = new Timer(this.ReadCallback, null, 0, ReadIntervalMs);
         }
 
@@ -69,6 +70,7 @@
         public virtual void Stop()
         {
             _running = false;
+            RuntimeStateTracker.MarkProgress("sensor:stop|" + this.GetSensorType());
             _readTimer?.Dispose();
         }
 
@@ -99,6 +101,7 @@
 
             try
             {
+                RuntimeStateTracker.MarkProgress("sensor:before-read|" + this.GetSensorType());
                 this.ReadSensorData();
 
                 bool invalidReading = _temperature == InvalidTemperature ||
@@ -108,16 +111,19 @@
 
                 if (invalidReading)
                 {
+                    RuntimeStateTracker.MarkProgress("sensor:invalid-read|" + this.GetSensorType());
                     this.RegisterReadFailure("invalid sensor values");
                     return;
                 }
 
+                RuntimeStateTracker.MarkProgress("sensor:after-read|" + this.GetSensorType());
                 this.RegisterReadSuccess();
             }
             catch (Exception ex)
             {
                 LogHelper.LogError($"Error reading sensor data in {this.GetSensorType()}: {ex.Message}");
                 this.SetErrorValues();
+                RuntimeStateTracker.MarkProgress("sensor:read-exception|" + this.GetSensorType());
                 this.RegisterReadFailure(ex.Message);
 
                 _readTimer.Change(ErrorIntervalMs, ReadIntervalMs);

--- a/ESP32-NF-MQTT-DHT/Settings/MqttSettings.cs
+++ b/ESP32-NF-MQTT-DHT/Settings/MqttSettings.cs
@@ -13,6 +13,7 @@
         public static string Broker => DeviceConfig.GetString("mqtt.broker", "mqtt.broker.com");
         public static int Port => DeviceConfig.GetInt32("mqtt.port", 1883); // set to 8883 when tls=true
         public static bool UseTls => DeviceConfig.GetBoolean("mqtt.tls", false);
+        public static bool UseLastWill => DeviceConfig.GetBoolean("mqtt.lwt", false);
         public static string ClientUsername => DeviceConfig.GetString("mqtt.user", "user");
         public static string ClientPassword => DeviceConfig.GetString("mqtt.pass", "pass");
 


### PR DESCRIPTION
Add runtime state tracking, MQTT health, and config mgmt

- Introduce RuntimeStateTracker for watchdog-based reboot and state persistence
- Enhance DeviceConfig with reload, value masking, and MQTT-based remote config commands
- Add new MQTT topics for system, WiFi, sensor, and runtime status
- Improve MQTT client thread safety with ClientSyncRoot lock
- Support MQTT Last Will and Testament (LWT) via config
- Refactor MqttPublishService for richer status/heartbeat and health reporting
- Enable MqttClientService to track MQTT health and auto-reconnect on publish failures
- Run InternetConnectionService in its own thread with clean disposal
- Support new MQTT system commands: getstate, getconfig, setconfig, reloadconfig, reconnectmqtt, reconnectwifi
- Improve sensor error handling, logging, and runtime progress reporting
- Ensure thread safety in OTA and MQTT publishing
- General code cleanup and improved error handling throughout